### PR TITLE
chore: prepare v0.3.2 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix runtime version constant from 0.3.0 to 0.3.2 after the v0.3.1 release.  
   v0.3.1リリース後のランタイムバージョン定数を0.3.0から0.3.2に修正.
+- Prevent runtime version drift by verifying the hard-coded CLI version against pyproject.toml in tests.  
+  ハードコードしたCLIバージョンをテストで pyproject.toml と照合することで, ランタイムバージョンのずれを再発しないようにした.
 
 ## [0.3.1] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-01
+
+### Fixed
+
+- Fix runtime version constant from 0.3.0 to 0.3.2 after the v0.3.1 release.  
+  v0.3.1リリース後のランタイムバージョン定数を0.3.0から0.3.2に修正.
+
 ## [0.3.1] - 2026-05-31
 
 ### Fixed
@@ -93,7 +100,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release as first version
 
-[unreleased]: https://github.com/noda-hiroyuki-kit/pre-commit-VBA/compare/v0.3.1...HEAD
+[unreleased]: https://github.com/noda-hiroyuki-kit/pre-commit-VBA/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/noda-hiroyuki-kit/pre-commit-VBA/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/noda-hiroyuki-kit/pre-commit-VBA/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/noda-hiroyuki-kit/pre-commit-VBA/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/noda-hiroyuki-kit/pre-commit-VBA/compare/v0.1.3...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.2] - 2026-06-01
 
+### Added
+
+- Add Dependabot configuration for the uv ecosystem with weekly update checks.
+  uv エコシステム向けに、週次で更新確認する Dependabot 設定を追加.
+
 ### Fixed
 
 - Fix runtime version constant from 0.3.0 to 0.3.2 after the v0.3.1 release.  
@@ -22,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refine Rubberduck Addin reference detection to avoid false positives from inactive/module-literal patterns and align detection with `Rubberduck.x32.tlb` / `Rubberduck.x64.tlb`. ([#55])  
   非アクティブな参照やモジュール内のリテラルによる誤検知を避けるように Rubberduck Addin 参照検知を改善し, `Rubberduck.x32.tlb` / `Rubberduck.x64.tlb` に合わせて判定するようにした.
+
 ## [0.3.0] - 2026-04-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the following to your `.pre-commit-config.yaml`:
 
 ```
   - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-    rev: v0.3.1
+    rev: v0.3.2
     hooks:
       - id: extract-vba-code
       - id: check-excel-book-version
@@ -67,7 +67,7 @@ If you can use `uv`, `mise` is not required.
         ---
         repos:
         - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.1
+            rev: v0.3.2
             hooks:
             - id: extract-vba-code
             - id: check-excel-book-version

--- a/README_JA.md
+++ b/README_JA.md
@@ -16,7 +16,7 @@ Pythonのスクリプトしても利用可能です.
 
 ```
   - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-    rev: v0.3.1
+    rev: v0.3.2
     hooks:
       - id: extract-vba-code
       - id: check-excel-book-version
@@ -68,7 +68,7 @@ Version check passed.
         ---
         repos:
         - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.1
+            rev: v0.3.2
             hooks:
             - id: extract-vba-code
             - id: check-excel-book-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pre-commit-vba"
-version = "0.3.1"
+version = "0.3.2"
 description = "Extracts VBA code from Excel files for managing VBA code in git and checks workbook version."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/pre_commit_vba/pre_commit_vba.py
+++ b/src/pre_commit_vba/pre_commit_vba.py
@@ -24,7 +24,7 @@ from zipfile import BadZipFile, ZipFile
 import typer
 from win32com.client import DispatchEx
 
-__version__ = "0.3.0"
+__version__ = "0.3.2"
 
 
 class UndefineTypeError(Exception):

--- a/tests/test_pre_commit_vba.py
+++ b/tests/test_pre_commit_vba.py
@@ -29,8 +29,8 @@ runner = CliRunner()
 def _project_version() -> str:
     """Read the project version from pyproject.toml."""
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    with pyproject_path.open("rb") as file:
-        return str(tomllib.load(file)["project"]["version"])
+    with pyproject_path.open("rb") as pyproject_file:
+        return str(tomllib.load(pyproject_file)["project"]["version"])
 
 
 class TestCodeMetadataPortionIsOkInTrailingWhitespaceCheck:

--- a/tests/test_pre_commit_vba.py
+++ b/tests/test_pre_commit_vba.py
@@ -4,6 +4,7 @@ import logging
 import re
 import shutil
 import subprocess
+import tomllib
 import typing
 from collections.abc import Generator
 from logging import DEBUG
@@ -23,6 +24,13 @@ if TYPE_CHECKING:
 from win32com.client import DispatchEx
 
 runner = CliRunner()
+
+
+def _project_version() -> str:
+    """Read the project version from pyproject.toml."""
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as file:
+        return str(tomllib.load(file)["project"]["version"])
 
 
 class TestCodeMetadataPortionIsOkInTrailingWhitespaceCheck:
@@ -318,6 +326,11 @@ class TestExtractCommandNegativeOptions:
         assert "create-gitignore: False" in caplog.text  # noqa: S101
 
 
+def test_runtime_version_matches_pyproject() -> None:
+    """Test that the runtime version matches pyproject.toml."""
+    assert pre_commit_vba.__version__ == _project_version()  # noqa: S101
+
+
 @pytest.mark.parametrize(
     "subcommand",
     [
@@ -339,6 +352,7 @@ def test_display_version_subcommand(subcommand: str) -> None:
     pattern = r"pre-commit-vba version: (.*)"
     match = re.search(pattern, text)
     assert match is not None, "Version string not found in output"  # noqa: S101
+    assert match.group(1) == pre_commit_vba.__version__  # noqa: S101
     sem_ver_pattern = (
         r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)"
         r"\.(?P<patch>0|[1-9]\d*)"

--- a/uv.lock
+++ b/uv.lock
@@ -595,7 +595,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit-vba"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "pywin32" },


### PR DESCRIPTION
## Summary
- Prepare the v0.3.2 release by adding Dependabot configuration for the uv ecosystem.
- Align version references across the project to v0.3.2.
- Add a regression test that prevents runtime version drift.

## Changes
- `.github/dependabot.yml` adds weekly uv dependency update PRs.
- `pyproject.toml`, `src/pre_commit_vba/pre_commit_vba.py`, and `uv.lock` are bumped to `0.3.2`.
- `README.md` and `README_JA.md` update example hook revisions to `v0.3.2`.
- `tests/test_pre_commit_vba.py` verifies the runtime version matches `pyproject.toml` and the CLI version output.
- `CHANGELOG.md` records the release notes.