### PR TITLE
docs: fix README yaml indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix YAML indentation in README examples for the `.pre-commit-config.yaml` snippets.
+  README の `.pre-commit-config.yaml` 例の YAML インデントを修正.
+
 ## [0.3.3] - 2026-06-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - Fix YAML indentation in README examples for the `.pre-commit-config.yaml` snippets.
   README の `.pre-commit-config.yaml` 例の YAML インデントを修正.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ If you can use `uv`, `mise` is not required.
         ---
         repos:
         - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.3
-            hooks:
+          rev: v0.3.3
+          hooks:
             - id: extract-vba-code
             - id: check-excel-book-version
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -68,8 +68,8 @@ Version check passed.
         ---
         repos:
         - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.3
-            hooks:
+          rev: v0.3.3
+          hooks:
             - id: extract-vba-code
             - id: check-excel-book-version
 


### PR DESCRIPTION
## Summary
- Fix YAML indentation in the README `.pre-commit-config.yaml` examples.
- Add a changelog note under Unreleased.

## Validation
- pre-commit hooks passed.
