### PR TITLE
fix: harden ExcelVbaExporter destructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `ExcelVbaExporter.__del__` defensive for partially initialized instances and avoid re-raising exceptions during cleanup.
+  `ExcelVbaExporter.__del__` を部分初期化インスタンスでも安全に動作するようにし, クリーンアップ時に例外を再送出しないようにした.
+- Handle pytest deprecation warnings in tests by updating test-side implementation details.
+  pytest の非推奨警告に対応するため, テスト実装の詳細を更新.
+
+
 ## [0.3.6] - 2026-06-25
 
 ### Changed

--- a/src/pre_commit_vba/pre_commit_vba.py
+++ b/src/pre_commit_vba/pre_commit_vba.py
@@ -268,12 +268,20 @@ class ExcelVbaExporter:
 
     def __del__(self) -> None:
         """Destructor to close workbook and quit app."""
-        try:
-            self.__workbook.Close(SaveChanges=False)
-            self.__app.Quit()
-        except Exception:
-            logger.exception("Error in destructor")
-            raise
+        workbook = getattr(self, "_ExcelVbaExporter__workbook", None)
+        app = getattr(self, "_ExcelVbaExporter__app", None)
+
+        if workbook is not None:
+            try:
+                workbook.Close(SaveChanges=False)
+            except Exception:
+                logger.exception("Error while closing workbook in destructor")
+
+        if app is not None:
+            try:
+                app.Quit()
+            except Exception:
+                logger.exception("Error while quitting Excel app in destructor")
 
 
 def vb_component_type_factory(module_name: str, type_id: int) -> IVbComponentType:

--- a/src/pre_commit_vba/pre_commit_vba.py
+++ b/src/pre_commit_vba/pre_commit_vba.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
+from contextlib import suppress
 from dataclasses import dataclass
 from logging import INFO, basicConfig, getLogger
 from pathlib import Path
@@ -271,17 +272,24 @@ class ExcelVbaExporter:
         workbook = getattr(self, "_ExcelVbaExporter__workbook", None)
         app = getattr(self, "_ExcelVbaExporter__app", None)
 
+        def _safe_log_exception(message: str) -> None:
+            logger_obj = globals().get("logger")
+            if logger_obj is None:
+                return
+            with suppress(Exception):
+                logger_obj.exception(message)
+
         if workbook is not None:
             try:
                 workbook.Close(SaveChanges=False)
-            except Exception:
-                logger.exception("Error while closing workbook in destructor")
+            except Exception:  # noqa: BLE001
+                _safe_log_exception("Error while closing workbook in destructor")
 
         if app is not None:
             try:
                 app.Quit()
-            except Exception:
-                logger.exception("Error while quitting Excel app in destructor")
+            except Exception:  # noqa: BLE001
+                _safe_log_exception("Error while quitting Excel app in destructor")
 
 
 def vb_component_type_factory(module_name: str, type_id: int) -> IVbComponentType:

--- a/tests/extract/test_excel_custom_ui_extractor.py
+++ b/tests/extract/test_excel_custom_ui_extractor.py
@@ -23,7 +23,8 @@ class TestExcelCustomUiExtractor:
     """Tests for ExcelCustomUiExtractor class."""
 
     @pytest.fixture(scope="class")
-    def sut(self) -> Generator[ExcelCustomUiExtractor]:
+    @classmethod
+    def sut(cls) -> Generator[ExcelCustomUiExtractor]:
         """Act first this tests."""
         common_folder = SettingsCommonFolder(
             Path(Path.cwd(), "tests", "test.xlsm"), ".VBA", include_extension=True

--- a/tests/extract/test_excel_vba_exporter.py
+++ b/tests/extract/test_excel_vba_exporter.py
@@ -23,7 +23,8 @@ class TestExcelVbaExporter:
     """Tests for ExcelVbaExporter class."""
 
     @pytest.fixture(scope="class")
-    def sut(self) -> Generator[ExcelVbaExporter]:
+    @classmethod
+    def sut(cls) -> Generator[ExcelVbaExporter]:
         """Act first this tests."""
         common_folder = SettingsCommonFolder(
             Path(Path.cwd(), "tests", "test.xlsm"), ".VBA", include_extension=True

--- a/tests/extract/test_excel_vba_exporter.py
+++ b/tests/extract/test_excel_vba_exporter.py
@@ -93,3 +93,27 @@ def test_destructor_swallows_close_and_quit_errors(
     # Prevent duplicate destructor logs when pytest later garbage-collects this object.
     delattr(exporter, "_ExcelVbaExporter__workbook")
     delattr(exporter, "_ExcelVbaExporter__app")
+
+
+def test_destructor_does_not_raise_when_logger_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test destructor does not fail when logger is unavailable during shutdown."""
+    exporter = ExcelVbaExporter.__new__(ExcelVbaExporter)
+    workbook = Mock()
+    app = Mock()
+    workbook.Close.side_effect = RuntimeError("close failed")
+    app.Quit.side_effect = RuntimeError("quit failed")
+    object.__setattr__(exporter, "_ExcelVbaExporter__workbook", workbook)
+    object.__setattr__(exporter, "_ExcelVbaExporter__app", app)
+
+    monkeypatch.setattr("src.pre_commit_vba.pre_commit_vba.logger", None)
+
+    exporter.__del__()
+
+    workbook.Close.assert_called_once_with(SaveChanges=False)
+    app.Quit.assert_called_once_with()
+
+    # Prevent duplicate destructor execution side effects on GC.
+    delattr(exporter, "_ExcelVbaExporter__workbook")
+    delattr(exporter, "_ExcelVbaExporter__app")

--- a/tests/extract/test_excel_vba_exporter.py
+++ b/tests/extract/test_excel_vba_exporter.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 import shutil
 from pathlib import Path
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -53,3 +54,42 @@ class TestExcelVbaExporter:
             Path.cwd(), "tests", "test.xlsm.VBA", "export", "sheet1.cls"
         )
         assert Path.is_file(expected_file)  # noqa: S101
+
+
+def test_destructor_does_not_raise_for_partially_initialized_instance() -> None:
+    """Test destructor handles partially-initialized instances safely."""
+    exporter = ExcelVbaExporter.__new__(ExcelVbaExporter)
+
+    exporter.__del__()
+
+
+def test_destructor_swallows_close_and_quit_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test destructor logs errors without re-raising exceptions."""
+    exporter = ExcelVbaExporter.__new__(ExcelVbaExporter)
+    workbook = Mock()
+    app = Mock()
+    workbook.Close.side_effect = RuntimeError("close failed")
+    app.Quit.side_effect = RuntimeError("quit failed")
+    object.__setattr__(exporter, "_ExcelVbaExporter__workbook", workbook)
+    object.__setattr__(exporter, "_ExcelVbaExporter__app", app)
+
+    mock_logger = Mock()
+    monkeypatch.setattr("src.pre_commit_vba.pre_commit_vba.logger", mock_logger)
+
+    exporter.__del__()
+
+    workbook.Close.assert_called_once_with(SaveChanges=False)
+    app.Quit.assert_called_once_with()
+
+    expected_calls = [
+        call("Error while closing workbook in destructor"),
+        call("Error while quitting Excel app in destructor"),
+    ]
+    mock_logger.exception.assert_has_calls(expected_calls)
+    assert mock_logger.exception.call_count == len(expected_calls)  # noqa: S101
+
+    # Prevent duplicate destructor logs when pytest later garbage-collects this object.
+    delattr(exporter, "_ExcelVbaExporter__workbook")
+    delattr(exporter, "_ExcelVbaExporter__app")

--- a/tests/extract/test_utf8_converter.py
+++ b/tests/extract/test_utf8_converter.py
@@ -25,7 +25,8 @@ class TestExcelVbaExporter:
     """Tests for ExcelVbaExporter class."""
 
     @pytest.fixture(scope="class")
-    def sut(self) -> Generator[Utf8Converter]:
+    @classmethod
+    def sut(cls) -> Generator[Utf8Converter]:
         """Act first this tests."""
         common_folder = SettingsCommonFolder(
             Path(Path.cwd(), "tests", "test.xlsm"), ".VBA", include_extension=True

--- a/tests/test_pre_commit_vba.py
+++ b/tests/test_pre_commit_vba.py
@@ -37,7 +37,8 @@ class TestCodeMetadataPortionIsOkInTrailingWhitespaceCheck:
     """Test class for code metadata portion in trailing whitespace check."""
 
     @pytest.fixture(scope="class")
-    def set_up(self) -> typing.tuple[subprocess.Popen, bytes]:
+    @classmethod
+    def set_up(cls) -> typing.tuple[subprocess.Popen, bytes]:
         """Set up for test."""
         runner.invoke(
             app,
@@ -165,7 +166,8 @@ class TestExtractCommandExistenceFiles:
     """Test class for extract command."""
 
     @pytest.fixture(scope="class")
-    def prepare_pre_existing_excel(self) -> typing.tuple[DispatchEx, CliRunner]:
+    @classmethod
+    def prepare_pre_existing_excel(cls) -> typing.tuple[DispatchEx, CliRunner]:
         """Fixture to prepare pre-existing Excel workbook for testing."""
         _excel_instance = DispatchEx("Excel.Application")
         _excel_instance.Visible = False
@@ -174,12 +176,13 @@ class TestExtractCommandExistenceFiles:
             Path(Path.cwd(), "tests", "test.xlsm"),
             ReadOnly=True,
         )
-        sut = self.sut()
+        sut = cls.sut()
         yield _excel_instance, sut
         _workbook.Close(SaveChanges=False)
         _excel_instance.Quit()
 
-    def sut(self) -> CliRunner:
+    @classmethod
+    def sut(cls) -> CliRunner:
         """Fixture for TestExtractCommandExistenceFiles."""
         return runner.invoke(
             app,
@@ -369,7 +372,8 @@ class TestCheckSubCommand:
     """Tests for check sub command."""
 
     @pytest.fixture(scope="class")
-    def prepare_pre_existing_excel(self) -> Generator:
+    @classmethod
+    def prepare_pre_existing_excel(cls) -> Generator:
         """Fixture to prepare pre-existing Excel workbook for testing."""
         _excel_instance = DispatchEx("Excel.Application")
         _excel_instance.Visible = False


### PR DESCRIPTION
## Summary
- make `ExcelVbaExporter.__del__` defensive for partially initialized instances
- avoid re-raising exceptions from destructor cleanup (`Close`/`Quit`)
- add regression tests for partial initialization and cleanup exception handling
- update Unreleased changelog entries including pytest deprecation handling

## Verification
- `uvx ruff check src/pre_commit_vba/pre_commit_vba.py tests/extract/test_excel_vba_exporter.py`
- `uv run pytest tests/extract/test_excel_vba_exporter.py -k "destructor"`