### PR TITLE
fix: align Document version property wording in release docs

### DIFF
--- a/docs/en/demo/step-06/preparation-release.md
+++ b/docs/en/demo/step-06/preparation-release.md
@@ -23,7 +23,7 @@ git switch -c release/v0.1.0
 
     Run the following in the VBE Immediate window.
         ```
-        ThisWorkbook.BuiltinDocumentProperties.Item("Document Version")="v0.1.0"
+        ThisWorkbook.BuiltinDocumentProperties("Document version")="v0.1.0"
         ```
 
 2. Remove unnecessary references.

--- a/docs/en/demo/step-06/preparation-release.md
+++ b/docs/en/demo/step-06/preparation-release.md
@@ -19,11 +19,11 @@ git switch -c release/v0.1.0
 
 ## Step 2: Update Workbook Information
 
-1. In the VBE, set Document Version to `v0.1.0`.
+1. In the VBE, set Document version to `v0.1.0`.
 
     Run the following in the VBE Immediate window.
         ```
-        ThisWorkbook.BuiltinDocumentProperties("Document version")="v0.1.0"
+        ThisWorkbook.BuiltinDocumentProperties.Item("Document version")="v0.1.0"
         ```
 
 2. Remove unnecessary references.

--- a/docs/ja/demo/step-06/preparation-release.md
+++ b/docs/ja/demo/step-06/preparation-release.md
@@ -19,11 +19,11 @@ git switch -c release/v0.1.0
 
 ## 手順 2: ブック情報を更新
 
-1. VBE で Document Version を `v0.1.0` にします.
+1. VBE で Document version を `v0.1.0` にします.
 
     VBEのイミディエイトで以下を実行します.
         ```
-        ThisWorkbook.BuiltinDocumentProperties("Document version")="v0.1.0"
+        ThisWorkbook.BuiltinDocumentProperties.Item("Document version")="v0.1.0"
         ```
 
 2. 不要な参照設定を外します.

--- a/docs/ja/demo/step-06/preparation-release.md
+++ b/docs/ja/demo/step-06/preparation-release.md
@@ -23,7 +23,7 @@ git switch -c release/v0.1.0
 
     VBEのイミディエイトで以下を実行します.
         ```
-        ThisWorkbook.BuiltinDocumentProperties.Item("Document Version")="v0.1.0"
+        ThisWorkbook.BuiltinDocumentProperties("Document version")="v0.1.0"
         ```
 
 2. 不要な参照設定を外します.


### PR DESCRIPTION
## Summary

Align the VBA snippet in release-preparation docs with implementation behavior.

## Changes

- docs/en/demo/step-06/preparation-release.md
- docs/ja/demo/step-06/preparation-release.md
- Update `BuiltinDocumentProperties.Item("Document Version")` to `BuiltinDocumentProperties("Document version")`