### PR TITLE
docs: add document links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENCE)
 
+[Document](https://noda-hiroyuki-kit.github.io/pre-commit-VBA/)
+
 ## Overview
 
 This is a pre-commit hook that extracts VBA code from Excel files to manage Excel VBA code with git.  

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,6 +5,8 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENCE)
 
+[Document](https://noda-hiroyuki-kit.github.io/pre-commit-VBA/)
+
 ## 概要
 
 ExcelのVBAコードをgitで管理するため, ExcelファイルよりVBAコードを抽出するpre-commit フックです.  


### PR DESCRIPTION
## Summary
- Add the project document link to the English and Japanese README files.

## Validation
- pre-commit hooks passed during commit.