### PR TITLE
feat(docs): sync docs version from pyproject.toml via Zensical macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Sync documentation version display with pyproject.toml by loading [project].version through Zensical macros.  
-  Zensical の macros で [project].version を読み込み、ドキュメントのバージョン表示を pyproject.toml と同期。
+- Sync documentation version display with `pyproject.toml` by loading `[project].version` through Zensical macros.  
+  Zensical の macros で `[project].version` を読み込み、ドキュメントのバージョン表示を `pyproject.toml` と同期。
 
 ## [0.3.10] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sync documentation version display with pyproject.toml by loading [project].version through Zensical macros.  
+  Zensical の macros で [project].version を読み込み、ドキュメントのバージョン表示を pyproject.toml と同期。
+
 ## [0.3.10] - 2026-07-12
 
 ### Added

--- a/docs/en/demo/step-04/setup-dev-environment.md
+++ b/docs/en/demo/step-04/setup-dev-environment.md
@@ -33,7 +33,7 @@ uv run pre-commit install
         ---
         repos:
           - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.10
+            rev: v{{project_version}}
             hooks:
               - id: extract-vba-code
               - id: check-excel-book-version

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -33,7 +33,7 @@ Install `mise` using the [official instructions](https://mise.jdx.dev/getting-st
         ---
         repos:
           - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.9
+            rev: v{{project_version}}
             hooks:
               - id: extract-vba-code
               - id: check-excel-book-version

--- a/docs/ja/demo/step-04/setup-dev-environment.md
+++ b/docs/ja/demo/step-04/setup-dev-environment.md
@@ -33,7 +33,7 @@ uv run pre-commit install
         ---
         repos:
           - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.10
+            rev: v{{project_version}}
             hooks:
               - id: extract-vba-code
               - id: check-excel-book-version

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -33,7 +33,7 @@ icon: lucide/package-open
         ---
         repos:
           - repo: https://github.com/noda-hiroyuki-kit/pre-commit-vba
-            rev: v0.3.9
+            rev: v{{project_version}}
             hooks:
               - id: extract-vba-code
               - id: check-excel-book-version

--- a/macros.py
+++ b/macros.py
@@ -1,4 +1,4 @@
-"""Part of the mkdocs-macros-plugin project."""
+"""Zensical macros for syncing docs version with pyproject metadata."""
 
 import tomllib
 from pathlib import Path

--- a/macros.py
+++ b/macros.py
@@ -13,7 +13,7 @@ class MacrosEnv(Protocol):
 
 def define_env(env: MacrosEnv) -> None:
     """Define variables and macros."""
-    pyproject = Path("pyproject.toml")
+    pyproject = Path(__file__).resolve().parent / "pyproject.toml"
     data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
 
     project = data.get("project")

--- a/macros.py
+++ b/macros.py
@@ -1,0 +1,29 @@
+"""Part of the mkdocs-macros-plugin project."""
+
+import tomllib
+from pathlib import Path
+from typing import Protocol
+
+
+class MacrosEnv(Protocol):
+    """Minimal interface required by define_env."""
+
+    variables: dict[str, str]
+
+
+def define_env(env: MacrosEnv) -> None:
+    """Define variables and macros."""
+    pyproject = Path("pyproject.toml")
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+
+    project = data.get("project")
+    if not isinstance(project, dict):
+        msg = "[project] section is missing in pyproject.toml"
+        raise KeyError(msg)
+
+    version = project.get("version")
+    if not isinstance(version, str):
+        msg = "[project].version must be a string in pyproject.toml"
+        raise TypeError(msg)
+
+    env.variables["project_version"] = version

--- a/zensical.toml
+++ b/zensical.toml
@@ -399,3 +399,7 @@ title = "PowerShell"
 buttons = "windows"
 prompt_literal_start = ["$"]
 # animate = true
+[project.markdown_extensions.zensical.extensions.macros]
+module_name = "macros"
+on_error_fail = true
+on_undefined = "strict"


### PR DESCRIPTION
## Summary
- add `macros.py` to load `[project].version` from `pyproject.toml`
- wire Zensical macros configuration to expose `project_version` in docs
- update English/Japanese docs pages to use the synced version value
- add an `Unreleased` changelog entry for this change

## Why
- prevent version drift between package metadata and documentation
- keep release docs maintenance simpler and consistent

## Validation
- `uv run pre-commit run --all-files`
- hooks passed (cspell, ruff, mypy, etc.)