### PR TITLE
fix(docs): use custom exceptions in macros module

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -5,6 +5,22 @@ from pathlib import Path
 from typing import Protocol
 
 
+class MissingProjectSectionError(RuntimeError):
+    """Raised when pyproject.toml does not contain a [project] section."""
+
+    def __init__(self) -> None:
+        """Initialize with a clear missing-project-section message."""
+        super().__init__("[project] section is missing in pyproject.toml")
+
+
+class InvalidProjectVersionError(RuntimeError):
+    """Raised when [project].version is missing or not a string."""
+
+    def __init__(self) -> None:
+        """Initialize with a clear invalid-version message."""
+        super().__init__("[project].version must be a string in pyproject.toml")
+
+
 class MacrosEnv(Protocol):
     """Minimal interface required by define_env."""
 
@@ -18,12 +34,10 @@ def define_env(env: MacrosEnv) -> None:
 
     project = data.get("project")
     if not isinstance(project, dict):
-        msg = "[project] section is missing in pyproject.toml"
-        raise KeyError(msg)
+        raise MissingProjectSectionError
 
     version = project.get("version")
     if not isinstance(version, str):
-        msg = "[project].version must be a string in pyproject.toml"
-        raise TypeError(msg)
+        raise InvalidProjectVersionError
 
     env.variables["project_version"] = version

--- a/macros.py
+++ b/macros.py
@@ -6,11 +6,11 @@ from typing import Protocol
 
 
 class MissingProjectSectionError(RuntimeError):
-    """Raised when pyproject.toml does not contain a [project] section."""
+    """Raised when pyproject.toml is missing or has an invalid [project] table."""
 
     def __init__(self) -> None:
-        """Initialize with a clear missing-project-section message."""
-        super().__init__("[project] section is missing in pyproject.toml")
+        """Initialize with a clear missing-or-invalid-project-table message."""
+        super().__init__("pyproject.toml is missing a valid [project] table")
 
 
 class InvalidProjectVersionError(RuntimeError):


### PR DESCRIPTION
## Summary
- replace built-in exceptions with small custom exceptions in `macros.py`
- keep docs version macro failures aligned with repository error-handling style

## Why
- address the review feedback on PR #102
- avoid TRY003-style lint issues from raising built-in exceptions with inline messages

## Validation
- `uvx ruff check macros.py`
- `uv run mypy macros.py`
- `uv run pre-commit run --all-files`